### PR TITLE
Update copyright year and add website link in footer

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -90,7 +90,7 @@
   </div>
   <hr class="mt-4" />
   <p class="mt-4 text-xs font-light text-gray-600 text-center">
-    Copyright 2024 Jeff Software | admin&commat;jeffsoftware.com |
+    Copyright 2026 <a class="text-blue-500" href="https://www.jeffsoftware.com" target="_blank">Jeff Software</a> | admin&commat;jeffsoftware.com |
     <a class="text-blue-500" href="https://x.com/jeffsoftware" target="_blank">&commat;jeffsoftware</a>
   </p>
 </main>


### PR DESCRIPTION
## Summary
Updated the footer copyright information to reflect the current year and added a hyperlink to the Jeff Software website.

## Key Changes
- Updated copyright year from 2024 to 2026
- Converted "Jeff Software" text to a clickable hyperlink pointing to https://www.jeffsoftware.com
- Added `target="_blank"` attribute to open the link in a new tab
- Applied consistent styling with the existing social media link using the `text-blue-500` class

## Implementation Details
The footer copyright text now includes an interactive link to the company website, improving navigation and user engagement while maintaining visual consistency with the existing Twitter/X link styling.

https://claude.ai/code/session_018Kv5vgCVe4itxFPhreVV2T