### PR TITLE
Enhance Dependabot skill with npm split version detection

### DIFF
--- a/.claude/plugins/jeff-plugin-project/skills/jeff-skill-dependabot-issue-resolution/SKILL.md
+++ b/.claude/plugins/jeff-plugin-project/skills/jeff-skill-dependabot-issue-resolution/SKILL.md
@@ -14,18 +14,23 @@ passes its tests, and dropping any update that breaks the build.
 - [ ] Listed every open Dependabot PR and its linked issue (if any)
 - [ ] Created branch chore/dependabot-batch-<date> off main
 
-## Angular/npm (skip section if no Angular sub-project exists)
+## Angular
 - [ ] Opened https://angular.dev/update-guide and confirmed the correct upgrade
       path from the current Angular version to the latest
 - [ ] Ran `ng update @angular/core @angular/cli` following the guide's steps
 - [ ] For every OTHER npm dependency being bumped by Dependabot: checked its
       required version range against the new Angular version's peer dependency
-      constraints — any conflict must be treated as a skip (do NOT force the
+      constraints — any conflict must be treated as a failure (do NOT force the
       version); see "On failure or incompatibility" below
 - [ ] Applied only the npm deps that are required to satisfy Angular's new
       peer dependency constraints (zone.js, typescript, test tooling, etc.)
 - [ ] Confirmed `ng build` and full test suite pass before touching anything else
 - [ ] Applied remaining standalone npm updates that are not Angular-constrained
+- [ ] For each npm package bumped: ran `npm install <pkg>@<new-version> --dry-run`
+      OR ran `npm ls <package-name>` after install to detect split versions
+- [ ] Ran `npm ls` for each bumped package and confirmed no split versions appear
+      in the tree (i.e., the bumped package is not also installed privately under
+      another package at a different version)
 - [ ] Confirmed `ng build` and full test suite still pass after standalone updates
 
 ## Other ecosystems (repeat block for each — Go, Python, etc.)
@@ -42,6 +47,9 @@ passes its tests, and dropping any update that breaks the build.
 - [ ] Full test suite passes for all sub-projects with all applied updates
 - [ ] Written report lists every dependency: updated vs. skipped, with reasons
 - [ ] Closed the Dependabot PR and linked issue for every successfully updated dep
+- [ ] Consolidated PR body includes every checklist item above with a written
+      explanation of what was done — no item is omitted if the technology exists
+      in this repo (e.g., if Angular is present, every Angular item must appear)
 - [ ] Consolidated PR merged to main
 ```
 
@@ -58,7 +66,7 @@ passes its tests, and dropping any update that breaks the build.
    between tracks — the backend (Go modules, etc.) can be updated before, after,
    or alongside the frontend. The ordering rules below apply only WITHIN a track.
 
-## Within the Angular/npm sub-project (if one exists)
+## Within the Angular sub-project (if one exists)
 
 The Angular-first rule is scoped to this sub-project only — it does not block or
 gate updates in other directories/ecosystems.
@@ -80,6 +88,13 @@ force the version.
 3. Only AFTER the above is stable, apply any remaining standalone npm updates
    that are independent of Angular. Do these LAST to avoid conflicts with the
    Angular update process.
+4. **For every npm package bumped (Angular-constrained or standalone):** before
+   applying, run `npm install <pkg>@<new-version> --dry-run`, OR after installing
+   run `npm ls <package-name>`. If the tree shows two different versions of the
+   same package — one at the top level and one nested privately under another
+   package — that is a compatibility conflict. Treat that bump as a failure and
+   exclude it following the steps in "On failure or incompatibility" below. This
+   is a mechanical, checkable rule, not a judgment call.
 
 ## Within any other sub-project / ecosystem (Go, Python, etc.)
 
@@ -114,7 +129,12 @@ incompatibility (e.g. conflicts with Angular's peer dependency constraints):
      broke, which version constraint was violated, or why, if known).
 2. For each dependency that was successfully updated, close its corresponding
    Dependabot PR and any linked issue.
-3. Merge the consolidated feature branch's PR into `main`.
+3. Write the consolidated PR body by going through every checklist item and
+   writing a short explanation of what was done for that item. Never omit a
+   checklist item that applies to this repo — if Angular is present, every Angular
+   item must appear in the PR body with its explanation. The PR body is the
+   canonical record of what was checked and why each decision was made.
+4. Merge the consolidated feature branch's PR into `main`.
 
 Leave the Dependabot PRs for the excluded/failed dependencies open so they can
 be revisited.


### PR DESCRIPTION
## Summary
Updated the Dependabot issue resolution skill documentation to add explicit checks for npm package split versions and require comprehensive PR body documentation of all checklist items.

## Key Changes

- **Added npm split version detection**: Introduced new checklist items requiring `npm install --dry-run` or `npm ls` verification to detect when a package is installed at multiple different versions in the dependency tree (top-level vs. nested under other packages). Split versions are now treated as compatibility failures.

- **Clarified Angular section naming**: Removed conditional language ("skip section if no Angular sub-project exists") from section headers to simplify the skill structure while keeping the conditional logic in the body text.

- **Enhanced PR documentation requirements**: Added explicit requirement that the consolidated PR body must include written explanations for every applicable checklist item, with no omissions based on which technologies exist in the repo (e.g., if Angular is present, all Angular items must be documented).

- **Formalized split version as mechanical rule**: Documented that split version detection is a checkable, objective rule rather than a judgment call, making it easier to apply consistently.

- **Expanded ordering guidance**: Added step 4 to the Angular sub-project ordering rules to explain the split version detection process and how to handle conflicts.

## Notable Details

The changes emphasize that the consolidated PR body serves as the canonical record of what was checked and why each decision was made, improving traceability and consistency across dependency updates.

https://claude.ai/code/session_01NCDbzTkRYPx3szTuNWdxPe