### PR TITLE
Extract Netlify deployment setup into dedicated skill

### DIFF
--- a/.claude/plugins/jeff-plugin-angular/agents/jeff-agent-angular-code-reviewer.md
+++ b/.claude/plugins/jeff-plugin-angular/agents/jeff-agent-angular-code-reviewer.md
@@ -6,6 +6,7 @@ skills:
   - jeff-skill-install-prettier
   - jeff-skill-angular-project
   - jeff-skill-angular-aws-cognito
+  - jeff-skill-angular-netlify
   - jeff-skill-tailwind-design-system
   - jeff-skill-install-dependabot
 ---

--- a/.claude/plugins/jeff-plugin-angular/agents/jeff-agent-angular-software-developer.md
+++ b/.claude/plugins/jeff-plugin-angular/agents/jeff-agent-angular-software-developer.md
@@ -6,6 +6,7 @@ skills:
   - jeff-skill-install-prettier
   - jeff-skill-angular-project
   - jeff-skill-angular-aws-cognito
+  - jeff-skill-angular-netlify
   - jeff-skill-tailwind-design-system
   - jeff-skill-install-dependabot
 ---

--- a/.claude/plugins/jeff-plugin-angular/skills/jeff-skill-angular-project/SKILL.md
+++ b/.claude/plugins/jeff-plugin-angular/skills/jeff-skill-angular-project/SKILL.md
@@ -38,14 +38,7 @@ Before proceeding:
 
      - `src/styles.css` should contain `@import "tailwindcss"`;
 
-5. Create a `netlify.toml` file in the root of the Angular project directory with the following content:
-
-   ```
-    [[redirects]]
-      from = "/*"
-      to = "/index.html"
-      status = 200
-   ```
+5. Set up Netlify deployment using the `jeff-skill-angular-netlify` skill.
 
 6. Create `.nvmrc` in the project root with the current Node LTS major version (visit https://nodejs.org/en and look for the "LTS" badge):
 
@@ -83,6 +76,7 @@ Before proceeding:
 
 - **jeff-skill-error-debugging-rca**: Use when debugging errors or test failures in Angular projects or related tools
 - **jeff-skill-angular-aws-cognito**: Integrate AWS Cognito authentication into the Angular app
+- **jeff-skill-angular-netlify**: Set up production Netlify deployment — full `netlify.toml` with caching headers, Makefile deploy target, and GitHub Actions CI/CD workflow
 - **jeff-skill-tailwind-design-system**: Apply Tailwind v4 design tokens, component patterns, and theming after initial project setup
 
 ## Additional resources


### PR DESCRIPTION
## Summary
Refactored Netlify deployment configuration out of the Angular project setup skill into a dedicated `jeff-skill-angular-netlify` skill. This improves modularity and allows deployment configuration to be managed independently.

## Key Changes
- Removed inline `netlify.toml` configuration instructions from the Angular project setup skill
- Created reference to new `jeff-skill-angular-netlify` skill for Netlify deployment setup
- Added `jeff-skill-angular-netlify` to both the Angular code reviewer and software developer agent skill lists
- Updated skill documentation to describe the new Netlify skill's scope (includes `netlify.toml`, caching headers, Makefile deploy target, and GitHub Actions CI/CD workflow)

## Implementation Details
- The Netlify deployment setup is now a separate, reusable skill that can be applied independently
- Both Angular agents (code reviewer and software developer) now have access to the Netlify skill
- The new skill encompasses a more comprehensive deployment setup than the previous inline configuration, including caching headers, deployment automation, and CI/CD workflow

https://claude.ai/code/session_01S4BwLcxTkfp25jJodtCTL8