### PR TITLE
Use Node 24 in deploy workflow

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: client/package-lock.json
 


### PR DESCRIPTION
Update `deploy-web.yml` to use Node 24, matching the minimum version required across all projects.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UinkhwVDpXmbR5WxgGKtgm)_