### PR TITLE
Add security headers to Netlify configuration

### DIFF
--- a/client/netlify.toml
+++ b/client/netlify.toml
@@ -4,6 +4,15 @@
   to = "/index.html"
   status = 200
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'none'"
+
 # index.html: browser must always revalidate; Netlify CDN holds it durably
 [[headers]]
   for = "/index.html"


### PR DESCRIPTION
## Summary
This PR adds a comprehensive set of security headers to the Netlify configuration to protect the application against common web vulnerabilities and attacks.

## Key Changes
- **X-Frame-Options**: Set to `DENY` to prevent clickjacking attacks by disallowing the site from being framed
- **X-Content-Type-Options**: Set to `nosniff` to prevent MIME type sniffing attacks
- **Referrer-Policy**: Set to `strict-origin-when-cross-origin` to control referrer information leakage
- **Permissions-Policy**: Restricts access to sensitive browser features (camera, microphone, geolocation)
- **Content-Security-Policy**: Implements a strict CSP that:
  - Restricts script execution to same-origin only (with specific hash allowance)
  - Allows inline styles but restricts other resources to same-origin
  - Disables object/embed elements
  - Prevents framing of the application

## Implementation Details
These headers are applied globally to all routes (`/*`) via Netlify's headers configuration, ensuring consistent security posture across the entire application. The CSP includes a specific script hash to allow a particular inline script while maintaining strict security controls.

https://claude.ai/code/session_019Jjue5gN7icQfUF74aLPNo