### PR TITLE
Upgrade Angular build and CLI to 22.0.3

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,8 +18,8 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@angular/build": "^22.0.2",
-        "@angular/cli": "^22.0.2",
+        "@angular/build": "^22.0.3",
+        "@angular/cli": "^22.0.3",
         "@angular/compiler-cli": "^22.0.2",
         "@tailwindcss/postcss": "^4.3.1",
         "@types/jasmine": "~5.1.0",
@@ -334,24 +334,6 @@
         "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.2.tgz",
-      "integrity": "sha512-l9lVG9k+baFMWXNsFUxwmxQaUZMkpkTn3vRpa1hs/vABzT/KnaDeweDtvvkS0NS1RYJenoxhONlMNEWuJ4VR1A==",
-      "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.2"
       }
     },
     "node_modules/@angular/build": {
@@ -6081,25 +6063,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.23.9",
-        "@babel/parser": "^7.23.9",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -10154,14 +10117,6 @@
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
-    },
-    "node_modules/zone.js": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -24,8 +24,8 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@angular/build": "^22.0.2",
-    "@angular/cli": "^22.0.2",
+    "@angular/build": "^22.0.3",
+    "@angular/cli": "^22.0.3",
     "@angular/compiler-cli": "^22.0.2",
     "@tailwindcss/postcss": "^4.3.1",
     "@types/jasmine": "~5.1.0",


### PR DESCRIPTION
## Summary
Updated Angular build tools to patch version 22.0.3 to incorporate bug fixes and improvements.

## Changes
- Bumped `@angular/build` from ^22.0.2 to ^22.0.3
- Bumped `@angular/cli` from ^22.0.2 to ^22.0.3

## Details
This is a patch-level upgrade within the 22.0.x release line. The `@angular/compiler-cli` dependency remains at ^22.0.2 and does not require an update at this time.

https://claude.ai/code/session_01HVjBV696yhk1GM25hnKZcS