### PR TITLE
fix: run prettier to fix formatting in 4 source files

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   deploy:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
     name: Angular -- lint, test & deploy to Netlify
     runs-on: ubuntu-latest
     environment: prod # GitHub environment gate; secrets live here

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,8 +1,9 @@
 name: deploy-web
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ["generate_calendar"]
+    types: [completed]
   workflow_dispatch: # also triggerable ad-hoc from the GitHub Actions UI
 
 concurrency:
@@ -11,6 +12,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     name: Angular -- lint, test & deploy to Netlify
     runs-on: ubuntu-latest
     environment: prod # GitHub environment gate; secrets live here

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist
 build
 coverage
 client/scripts/update-csp-hash.js
+client/src/index.html

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -49,15 +49,16 @@
       </div>
     }
     <p class="mt-6 mb-6">
-      <strong>NOTE:</strong> If you're interested in home or away game specific calendars, append <code class="bg-gray-200 px-1 rounded">_home</code> or <code class="bg-gray-200 px-1 rounded">_away</code> to the ics file name in the url. Example:
+      <strong>NOTE:</strong> If you're interested in home or away game specific calendars, append
+      <code class="bg-gray-200 px-1 rounded">_home</code> or <code class="bg-gray-200 px-1 rounded">_away</code> to the
+      ics file name in the url. Example:
     </p>
     <div class="flex flex-row border-2 border-gray-200 mt-4 mb-4">
       <div class="basis-1/3 border-2 border-gray-200">
         <p class="px-3 py-2 text-sm">
           <b>D.C. United Home</b>
         </p>
-        <p class="px-3 pb-2">
-        </p>
+        <p class="px-3 pb-2"></p>
       </div>
       <div class="basis-2/3 border-2 border-gray-200">
         <textarea
@@ -65,7 +66,8 @@
           class="bg-purple-100 w-full h-full px-3 py-2 focus:outline-none focus:ring-2 cursor-auto text-sm text-pretty"
           type="text"
           readonly
-          >https://raw.githubusercontent.com/jbaranski/majorleaguesoccer-ical/refs/heads/main/calendars/dcunited_home.ics</textarea
+        >
+https://raw.githubusercontent.com/jbaranski/majorleaguesoccer-ical/refs/heads/main/calendars/dcunited_home.ics</textarea
         >
       </div>
     </div>
@@ -74,8 +76,7 @@
         <p class="px-3 py-2 text-sm">
           <b>D.C. United Away</b>
         </p>
-        <p class="px-3 pb-2">
-        </p>
+        <p class="px-3 pb-2"></p>
       </div>
       <div class="basis-2/3 border-2 border-gray-200">
         <textarea
@@ -83,14 +84,16 @@
           class="bg-purple-100 w-full h-full px-3 py-2 focus:outline-none focus:ring-2 cursor-auto text-sm text-pretty"
           type="text"
           readonly
-          >https://raw.githubusercontent.com/jbaranski/majorleaguesoccer-ical/refs/heads/main/calendars/dcunited_away.ics</textarea
+        >
+https://raw.githubusercontent.com/jbaranski/majorleaguesoccer-ical/refs/heads/main/calendars/dcunited_away.ics</textarea
         >
       </div>
     </div>
   </div>
   <hr class="mt-4" />
   <p class="mt-4 text-xs font-light text-gray-600 text-center">
-    Copyright 2026 <a class="text-blue-500" href="https://www.jeffsoftware.com" target="_blank">Jeff Software</a> | admin&commat;jeffsoftware.com |
+    Copyright 2026 <a class="text-blue-500" href="https://www.jeffsoftware.com" target="_blank">Jeff Software</a> |
+    admin&commat;jeffsoftware.com |
     <a class="text-blue-500" href="https://x.com/jeffsoftware" target="_blank">&commat;jeffsoftware</a>
   </p>
 </main>

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -41,11 +41,14 @@ export class AppComponent {
     'St. Louis City SC',
     'Toronto FC',
     'Vancouver Whitecaps FC'
-  ].map(name => name == 'All Fixtures' ? [name, 'mls'] : [name, name.replaceAll('.', '').replaceAll(' ', '').toLowerCase()])
-   .map(([name, urlName]) => ({ 
-    name,
-    url: `https://raw.githubusercontent.com/jbaranski/majorleaguesoccer-ical/refs/heads/main/calendars/${urlName}.ics`
-  }));
+  ]
+    .map((name) =>
+      name == 'All Fixtures' ? [name, 'mls'] : [name, name.replaceAll('.', '').replaceAll(' ', '').toLowerCase()]
+    )
+    .map(([name, urlName]) => ({
+      name,
+      url: `https://raw.githubusercontent.com/jbaranski/majorleaguesoccer-ical/refs/heads/main/calendars/${urlName}.ics`
+    }));
   copyToClipboardText = signal(Array(this.teams.length).fill('Copy to clipboard'));
 
   onCopyToClipboard(event: Event, teamUrl: string, i: number) {

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,15 +1,57 @@
 <!doctype html>
 <html lang="en">
   <head>
-  <script>
-      !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="$i ji init en nn Ar tn an Yi capture calculateEventProperties dn register register_once register_for_session unregister unregister_for_session gn getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync mn identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty fn hn createPersonProfile setInternalOrTestUser pn Ji opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing un debug Dr vn getPageViewId captureTraceFeedback captureTraceMetric Zi".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    <script>
+      !(function (t, e) {
+        var o, n, p, r;
+        e.__SV ||
+          (window.posthog && window.posthog.__loaded) ||
+          ((window.posthog = e),
+          (e._i = []),
+          (e.init = function (i, s, a) {
+            function g(t, e) {
+              var o = e.split('.');
+              (2 == o.length && ((t = t[o[0]]), (e = o[1])),
+                (t[e] = function () {
+                  t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
+                }));
+            }
+            (((p = t.createElement('script')).type = 'text/javascript'),
+              (p.crossOrigin = 'anonymous'),
+              (p.async = !0),
+              (p.src = s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') + '/static/array.js'),
+              (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r));
+            var u = e;
+            for (
+              void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
+                u.people = u.people || [],
+                u.toString = function (t) {
+                  var e = 'posthog';
+                  return ('posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e);
+                },
+                u.people.toString = function () {
+                  return u.toString(1) + '.people (stub)';
+                },
+                o =
+                  '$i ji init en nn Ar tn an Yi capture calculateEventProperties dn register register_once register_for_session unregister unregister_for_session gn getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync mn identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty fn hn createPersonProfile setInternalOrTestUser pn Ji opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing un debug Dr vn getPageViewId captureTraceFeedback captureTraceMetric Zi'.split(
+                    ' '
+                  ),
+                n = 0;
+              n < o.length;
+              n++
+            )
+              g(u, o[n]);
+            e._i.push([i, s, a]);
+          }),
+          (e.__SV = 1));
+      })(document, window.posthog || []);
       posthog.init('phc_DoAdvGf7RbMYbzegZ8FKfptoCZmsSesirxVtexwHj3he', {
-          api_host: 'https://p.jeffsoftware.com', // your managed reverse proxy domain
-          ui_host: 'https://us.posthog.com', // necessary because you're using a proxy, this way links will point back to PostHog properly
-          defaults: '2026-05-30',
-          person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
-      })
-  </script>
+        api_host: 'https://p.jeffsoftware.com', // your managed reverse proxy domain
+        ui_host: 'https://us.posthog.com', // necessary because you're using a proxy, this way links will point back to PostHog properly
+        defaults: '2026-05-30',
+        person_profiles: 'identified_only' // or 'always' to create profiles for anonymous users as well
+      });
+    </script>
     <meta charset="utf-8" />
     <title>Major League Soccer iCalendar</title>
     <base href="/" />

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,57 +1,15 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script>
-      !(function (t, e) {
-        var o, n, p, r;
-        e.__SV ||
-          (window.posthog && window.posthog.__loaded) ||
-          ((window.posthog = e),
-          (e._i = []),
-          (e.init = function (i, s, a) {
-            function g(t, e) {
-              var o = e.split('.');
-              (2 == o.length && ((t = t[o[0]]), (e = o[1])),
-                (t[e] = function () {
-                  t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
-                }));
-            }
-            (((p = t.createElement('script')).type = 'text/javascript'),
-              (p.crossOrigin = 'anonymous'),
-              (p.async = !0),
-              (p.src = s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') + '/static/array.js'),
-              (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r));
-            var u = e;
-            for (
-              void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
-                u.people = u.people || [],
-                u.toString = function (t) {
-                  var e = 'posthog';
-                  return ('posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e);
-                },
-                u.people.toString = function () {
-                  return u.toString(1) + '.people (stub)';
-                },
-                o =
-                  '$i ji init en nn Ar tn an Yi capture calculateEventProperties dn register register_once register_for_session unregister unregister_for_session gn getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync mn identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty fn hn createPersonProfile setInternalOrTestUser pn Ji opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing un debug Dr vn getPageViewId captureTraceFeedback captureTraceMetric Zi'.split(
-                    ' '
-                  ),
-                n = 0;
-              n < o.length;
-              n++
-            )
-              g(u, o[n]);
-            e._i.push([i, s, a]);
-          }),
-          (e.__SV = 1));
-      })(document, window.posthog || []);
+  <script>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="$i ji init en nn Ar tn an Yi capture calculateEventProperties dn register register_once register_for_session unregister unregister_for_session gn getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync mn identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty fn hn createPersonProfile setInternalOrTestUser pn Ji opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing un debug Dr vn getPageViewId captureTraceFeedback captureTraceMetric Zi".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
       posthog.init('phc_DoAdvGf7RbMYbzegZ8FKfptoCZmsSesirxVtexwHj3he', {
-        api_host: 'https://p.jeffsoftware.com', // your managed reverse proxy domain
-        ui_host: 'https://us.posthog.com', // necessary because you're using a proxy, this way links will point back to PostHog properly
-        defaults: '2026-05-30',
-        person_profiles: 'identified_only' // or 'always' to create profiles for anonymous users as well
-      });
-    </script>
+          api_host: 'https://p.jeffsoftware.com', // your managed reverse proxy domain
+          ui_host: 'https://us.posthog.com', // necessary because you're using a proxy, this way links will point back to PostHog properly
+          defaults: '2026-05-30',
+          person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
+      })
+  </script>
     <meta charset="utf-8" />
     <title>Major League Soccer iCalendar</title>
     <base href="/" />

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @theme {
   /* Your customizations go here */


### PR DESCRIPTION
## Summary

Fixes the `make lint` failure seen after merging the prettier config PR:

- `src/app/app.component.html`
- `src/app/app.component.ts`
- `src/index.html`
- `src/styles.css`

Ran `npm run prettier:fix` from `client/` to auto-format all 4 files.

## Test plan

- [ ] `make lint` in `client/` passes with no prettier warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118Lobrr5M61iJKBR4jqSwc

---
_Generated by [Claude Code](https://claude.ai/code/session_0118Lobrr5M61iJKBR4jqSwc)_