### PR TITLE
fix: add src/index.html to client/.prettierignore

### DIFF
--- a/client/.prettierignore
+++ b/client/.prettierignore
@@ -3,3 +3,4 @@
 *.ico
 *.js
 *.png
+src/index.html


### PR DESCRIPTION
## Summary

Fixes the `make lint` failure after PR #54 was merged.

Root cause: `.prettierignore` patterns are resolved relative to the CWD where prettier is invoked, not the location of the `.prettierignore` file. CI runs prettier from `client/`, so `client/src/index.html` in the repo root `.prettierignore` resolves to `client/client/src/index.html` (doesn't exist) and never fires.

Fix: add `src/index.html` to `client/.prettierignore`, which prettier finds immediately in its CWD and resolves correctly.

## Test plan

- [ ] `make lint` in `client/` passes with no prettier warnings for `src/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118Lobrr5M61iJKBR4jqSwc

---
_Generated by [Claude Code](https://claude.ai/code/session_0118Lobrr5M61iJKBR4jqSwc)_