### PR TITLE
fix: remove stale auto-generated tests from app.component.spec.ts

### DIFF
--- a/client/src/app/app.component.spec.ts
+++ b/client/src/app/app.component.spec.ts
@@ -13,17 +13,4 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
-
-  it(`should have the 'client' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('client');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, client');
-  });
 });


### PR DESCRIPTION
## Summary

Removes two stale auto-generated Angular CLI tests that reference `app.title` and an `<h1>` element — neither exist on `AppComponent`. Only the "should create the app" smoke test is kept.

Verified: `make lint` and `make test` both pass (`1 SUCCESS`).

## Test plan

- [ ] `make lint` passes (no prettier warnings)
- [ ] `make test` passes (1 test: should create the app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118Lobrr5M61iJKBR4jqSwc

---
_Generated by [Claude Code](https://claude.ai/code/session_0118Lobrr5M61iJKBR4jqSwc)_