### PR TITLE
fix: add PostHog proxy domain to script-src CSP

### DIFF
--- a/client/netlify.toml
+++ b/client/netlify.toml
@@ -13,7 +13,7 @@
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-LdvbMBsgo6OtW1PE13RAS10bBCYeawIQUC2GsFcA09M=' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; connect-src 'self' https://p.jeffsoftware.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'none'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-LdvbMBsgo6OtW1PE13RAS10bBCYeawIQUC2GsFcA09M=' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' https://p.jeffsoftware.com; connect-src 'self' https://p.jeffsoftware.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; object-src 'none'; frame-ancestors 'none'"
 
 # index.html: browser must always revalidate; Netlify CDN holds it durably
 [[headers]]


### PR DESCRIPTION
## Summary

Fixes the production CSP error:
```
Loading the script 'https://p.jeffsoftware.com/static/array.js' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-hashes' ..."
```

PostHog's inline init script (covered by the sha256 hash) dynamically loads additional scripts from the proxy (`https://p.jeffsoftware.com/static/array.js`). `connect-src` alone does not cover script loads -- `script-src` must also allow the domain.

Also removes two stale auto-generated Angular CLI tests that were already fixed in PR #57 but need to be included here since the branch was reset to main after that merge.

## Test plan

- [ ] `make lint` passes
- [ ] `make test` passes (1 test: should create the app)
- [ ] PostHog loads without CSP errors in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118Lobrr5M61iJKBR4jqSwc

---
_Generated by [Claude Code](https://claude.ai/code/session_0118Lobrr5M61iJKBR4jqSwc)_