### PR TITLE
chore: minify site.webmanifest and add to .prettierignore

### DIFF
--- a/client/.prettierignore
+++ b/client/.prettierignore
@@ -4,3 +4,4 @@
 *.js
 *.png
 src/index.html
+public/site.webmanifest

--- a/client/public/site.webmanifest
+++ b/client/public/site.webmanifest
@@ -1,11 +1,1 @@
-{
-  "name": "",
-  "short_name": "",
-  "icons": [
-    { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
-  ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
-  "display": "standalone"
-}
+{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}


### PR DESCRIPTION
## Summary

- Minify `client/public/site.webmanifest` to a single line
- Add `public/site.webmanifest` to `client/.prettierignore` so prettier never reformats it

---
_Generated by [Claude Code](https://claude.ai/code/session_0118Lobrr5M61iJKBR4jqSwc)_