### PR TITLE
Bump tailwindcss to ^4.3.1

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -30,8 +30,11 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.2.0",
         "prettier": "^3.8.4",
-        "tailwindcss": "^4.1.17",
+        "tailwindcss": "^4.3.1",
         "typescript": "~6.0.0"
+      },
+      "engines": {
+        "node": ">= 24.0.0"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/client/package.json
+++ b/client/package.json
@@ -40,7 +40,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.2.0",
     "prettier": "^3.8.4",
-    "tailwindcss": "^4.1.17",
+    "tailwindcss": "^4.3.1",
     "typescript": "~6.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrades `tailwindcss` from `^4.1.17` to `^4.3.1`

No migration required -- project was already on Tailwind v4.

## Test plan

- [x] `ng build --configuration=production` succeeds
- [x] `ng test --watch=false --browsers=ChromeHeadlessNoSandbox` -- 1 test PASSED

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPutEvZjWqBVztTUgSmWfQ)_