### PR TITLE
Add global error listener provider to app configuration

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -31,7 +31,7 @@
         "karma-jasmine-html-reporter": "~2.2.0",
         "prettier": "^3.8.4",
         "tailwindcss": "^4.3.1",
-        "typescript": "~6.0.0"
+        "typescript": "~6.0.3"
       },
       "engines": {
         "node": ">= 24.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -41,6 +41,6 @@
     "karma-jasmine-html-reporter": "~2.2.0",
     "prettier": "^3.8.4",
     "tailwindcss": "^4.3.1",
-    "typescript": "~6.0.0"
+    "typescript": "~6.0.3"
   }
 }

--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -1,8 +1,8 @@
-import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
+import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZonelessChangeDetection(), provideRouter(routes)]
+  providers: [provideBrowserGlobalErrorListeners(), provideZonelessChangeDetection(), provideRouter(routes)]
 };


### PR DESCRIPTION
## Summary
This PR adds browser global error listener support to the Angular application configuration to improve error handling and observability.

## Key Changes
- Added `provideBrowserGlobalErrorListeners` to the application providers in `app.config.ts`
- This enables the application to listen to and handle global browser errors (uncaught exceptions and unhandled promise rejections)
- Updated TypeScript dependency from `~6.0.0` to `~6.0.3` (patch version bump)

## Implementation Details
The `provideBrowserGlobalErrorListeners()` provider is now included in the application configuration alongside the existing zoneless change detection and router providers. This allows the application to capture and respond to global errors that occur outside of Angular's zone, which is particularly useful in zoneless change detection mode for comprehensive error tracking and logging.

https://claude.ai/code/session_01FiBDbmMJcNaYpHPbQMvo1x