### PR TITLE
add .claude to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ build
 coverage
 client/scripts/update-csp-hash.js
 client/src/index.html
+.claude


### PR DESCRIPTION
Add `.claude` to `.prettierignore` so prettier doesn't format Claude Code plugin/agent files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUKcjgx1ejiZy3J4tCDswp)_