### PR TITLE
Upgrade Angular build and CLI to v22.0.4

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,8 +18,8 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@angular/build": "^22.0.3",
-        "@angular/cli": "^22.0.3",
+        "@angular/build": "^22.0.4",
+        "@angular/cli": "^22.0.4",
         "@angular/compiler-cli": "^22.0.2",
         "@tailwindcss/postcss": "^4.3.1",
         "@types/jasmine": "~5.1.0",
@@ -274,13 +274,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2200.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.3.tgz",
-      "integrity": "sha512-Ru+ucNkTZr98gmeaBYjq3zZwh32yGofAeB8+GJL/ZNy0x+7NzK6b+OatdzwT4l7mCWFC5vL8iYu0B4++M66Jpg==",
+      "version": "0.2200.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.4.tgz",
+      "integrity": "sha512-X/iEQiZ0pRmpjUt11jCM+mtOLRl4XxI9hnM0IC9aAcsm5AzRBb9WY6QIEqOSficjxC/+MI7MGwrerrcP6QN8UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.3",
+        "@angular-devkit/core": "22.0.4",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.3.tgz",
-      "integrity": "sha512-pBjo1JKwI8GbNdTo/Z0g+ZekqlTBCJWmzIC5fgGW9q5eRjl1y+5N5jlX8UAyyMCeUTTwsfpQdkAM2jyi/jcvjA==",
+      "version": "22.0.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.4.tgz",
+      "integrity": "sha512-zA2UJSMAU3su5uJTOn5ul/gCLRcw6/uIQ6EC5v/Ju/ePjgDIw9R3y3MAvWQ4Ibi/fXiq0FVxpF8hE7RUclYmJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -321,13 +321,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.3.tgz",
-      "integrity": "sha512-aIp5sQDHdhyLbeVJF/k3w079XhW91mNAo2OliZllBCjoYhkIXNnWECOx5y2nXtCChyFJA2+ZgNST7NIDvtz1/w==",
+      "version": "22.0.4",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.4.tgz",
+      "integrity": "sha512-VRxL1hD/Q3TQglM6EfQ0ksAW4OIvtKyZgtaUpyGsJRfD6tGmLFn7MDnmyyq1ceLX/Clq+3tzH/wN0tF6rcE0jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.3",
+        "@angular-devkit/core": "22.0.4",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.4.0",
@@ -340,14 +340,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.3.tgz",
-      "integrity": "sha512-pwFDRCp+r8JK+fCtScPldizcS75wSpn3u/4goDf2FRa4Y9wzTvq6T0XpFHqdpgq6HcIlIZWwAqqW6XqEM9/pKQ==",
+      "version": "22.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.4.tgz",
+      "integrity": "sha512-hst/KhP5mMPajY32l7qmyW/5fuqrMHCjHEeNhMMNqP82+j8jPBFfMEL26AH9w2kIIdKGpC3WKN5JgLotyFD7tQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2200.3",
+        "@angular-devkit/architect": "0.2200.4",
         "@babel/core": "7.29.0",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -363,7 +363,7 @@
         "mrmime": "2.0.1",
         "parse5-html-rewriting-stream": "8.0.1",
         "picomatch": "4.0.4",
-        "piscina": "5.1.4",
+        "piscina": "5.2.0",
         "rollup": "4.60.2",
         "sass": "1.99.0",
         "semver": "7.7.4",
@@ -388,7 +388,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.0.3",
+        "@angular/ssr": "^22.0.4",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -442,19 +442,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.3.tgz",
-      "integrity": "sha512-YgFzfQu3Il6Aka8IdH4pk7faieICaca5Wklke0jMTKBUxzLGWw82X7+J/Lox7FERb6LHtxiHpa6ttXqerCZvgg==",
+      "version": "22.0.4",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.4.tgz",
+      "integrity": "sha512-3eJy6VoNlgskKFzvqy3AJsYXFRhSBLLGObF2iTpJymsukuxWUen7hlVVVWrO5++bW1LEgd6PTCCD5fdT2UuRiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2200.3",
-        "@angular-devkit/core": "22.0.3",
-        "@angular-devkit/schematics": "22.0.3",
+        "@angular-devkit/architect": "0.2200.4",
+        "@angular-devkit/core": "22.0.4",
+        "@angular-devkit/schematics": "22.0.4",
         "@inquirer/prompts": "8.4.2",
         "@listr2/prompt-adapter-inquirer": "4.2.3",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@schematics/angular": "22.0.3",
+        "@schematics/angular": "22.0.4",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.52.0",
         "ini": "6.0.0",
@@ -2199,6 +2199,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2216,6 +2219,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2233,6 +2239,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2250,6 +2259,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2267,6 +2279,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2284,6 +2299,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2301,6 +2319,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3336,14 +3357,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.3.tgz",
-      "integrity": "sha512-iAUqIoRcK1CCHDm5E4Q1SI7rpVtsHJ+0qv5ll72wV3C1eCNdeDuGV0lX7PXEEkwd4y//s6yqI9o7f6VZZd6Fbw==",
+      "version": "22.0.4",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.4.tgz",
+      "integrity": "sha512-P3V3tkqIR+n0GJSv0ibf34/zMtKbFp6kaTjBe5cm/RyXuHbmdaPYjk8PNphkGMypDtWCof1RtNnW/hl832Wnew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.3",
-        "@angular-devkit/schematics": "22.0.3",
+        "@angular-devkit/core": "22.0.4",
+        "@angular-devkit/schematics": "22.0.4",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -8088,9 +8109,9 @@
       }
     },
     "node_modules/piscina": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
-      "integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.2.0.tgz",
+      "integrity": "sha512-DszUCKeVN/5G5QKo6jAVHL8fmKnkJvQ0ACiVgY7YGCq3TUB2oznAOayvZPIAdEThvhczkXR+qm3IHsNXpFCYfA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/client/package.json
+++ b/client/package.json
@@ -28,8 +28,8 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@angular/build": "^22.0.3",
-    "@angular/cli": "^22.0.3",
+    "@angular/build": "^22.0.4",
+    "@angular/cli": "^22.0.4",
     "@angular/compiler-cli": "^22.0.2",
     "@tailwindcss/postcss": "^4.3.1",
     "@types/jasmine": "~5.1.0",


### PR DESCRIPTION
## Summary
Updated Angular build tools to the latest patch version to incorporate bug fixes and improvements.

## Changes
- Bumped `@angular/build` from v22.0.3 to v22.0.4
- Bumped `@angular/cli` from v22.0.3 to v22.0.4

## Details
This is a patch-level upgrade of the Angular build toolchain. The `@angular/compiler-cli` dependency remains at v22.0.2 and is compatible with these updated versions. This update ensures the project benefits from the latest bug fixes and stability improvements in the Angular build pipeline.

https://claude.ai/code/session_017yCk5irztReKUfrVoF8PkT