### PR TITLE
chore(deps): consolidate Dependabot batch update (2026-07-11)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,8 +18,8 @@
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@angular/build": "^22.0.5",
-        "@angular/cli": "^22.0.5",
+        "@angular/build": "^22.0.6",
+        "@angular/cli": "^22.0.6",
         "@angular/compiler-cli": "^22.0.6",
         "@tailwindcss/postcss": "^4.3.2",
         "@types/jasmine": "~5.1.0",
@@ -29,7 +29,7 @@
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.2.0",
-        "prettier": "^3.9.3",
+        "prettier": "^3.9.5",
         "tailwindcss": "^4.3.2",
         "typescript": "~6.0.3"
       },
@@ -274,13 +274,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2200.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.5.tgz",
-      "integrity": "sha512-Fbki7xEx37gn8uH5AFOh0EmfGV4y5xag2fTv1vn6KxY/h33L02KuAjiUX3h2YmSjnYSc1dXto3Q5c4lWs/I5Zw==",
+      "version": "0.2200.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.6.tgz",
+      "integrity": "sha512-wTjUfiT5iEMc9+9z2zo1QGtzLpXk5Xx0bV6/zTO4n6+BCC0qReuYnIYt0iJCh649Q0vHq5++0zmZZK0KyXVMZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.5",
+        "@angular-devkit/core": "22.0.6",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.5.tgz",
-      "integrity": "sha512-xxd3b9X0bbdGuYqDj1OgxtlGotrb/gsxQ5+4aqivWBHq4q/1RI8JfVB7gqcoYTvAfTq63Dwsk7Qd33hC4yJ1Wg==",
+      "version": "22.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.6.tgz",
+      "integrity": "sha512-uAZ7TPn+8sDZcFtiM5nQpmqaR9lspLAf7RY7t7TXYP794001khRf+F/AhmONxmgFPWY01+eeJSvBx+FEnHCb0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -321,13 +321,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.5.tgz",
-      "integrity": "sha512-yKkImZuFLIbylmk1REyoW3EWQeqnr6qwtrzs4EPeaJgzjj+MZurq5slQ3fanK9lfX2q+W+dnSQFKBXHxlUGJ8Q==",
+      "version": "22.0.6",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.6.tgz",
+      "integrity": "sha512-7bSiye4UrxvhYvYp1YIpVSVOFQZ75EXP3EE5/ShM3cPNtUTdXJiwHkD8SiLHNhPTB6Mzrq5tp1YlAXXRg/WgLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.5",
+        "@angular-devkit/core": "22.0.6",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.4.0",
@@ -340,14 +340,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.5.tgz",
-      "integrity": "sha512-uVXf1cSKTMDvpiP5x0X8h7D7dICHC2XsbmvRYtxdyTRy+zJduqtCdZTwnwmCrwIc5hOF+bmwa5p17P6XirYVfw==",
+      "version": "22.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.6.tgz",
+      "integrity": "sha512-mIp1snH1haw4pKiJwUmKyp9f31NRUTeUwqrl9W59X3Iv54egOnD1EdCc0jsW7WJVr/JHRZYVt/ooFelUB8uV8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2200.5",
+        "@angular-devkit/architect": "0.2200.6",
         "@babel/core": "7.29.0",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -388,7 +388,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-server": "^22.0.0",
         "@angular/service-worker": "^22.0.0",
-        "@angular/ssr": "^22.0.5",
+        "@angular/ssr": "^22.0.6",
         "istanbul-lib-instrument": "^6.0.0",
         "karma": "^6.4.0",
         "less": "^4.2.0",
@@ -442,19 +442,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.5.tgz",
-      "integrity": "sha512-BYg2dWsbqdbpv3UVLNtDns1DoUbsROR8htPPIJEETj4Nfu7VF+g0nnM1CX2Ia+3002xtASgHp4YnRGQN/vAhWA==",
+      "version": "22.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.6.tgz",
+      "integrity": "sha512-/sEN1hVcywSML+yWrr/T7gbuGfIrZwKC+WhiOv5GksSQVUrSujWnMX4meRJ5ocG/Ie8UN48LJ7LVDsm32NBt1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2200.5",
-        "@angular-devkit/core": "22.0.5",
-        "@angular-devkit/schematics": "22.0.5",
+        "@angular-devkit/architect": "0.2200.6",
+        "@angular-devkit/core": "22.0.6",
+        "@angular-devkit/schematics": "22.0.6",
         "@inquirer/prompts": "8.4.2",
         "@listr2/prompt-adapter-inquirer": "4.2.3",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@schematics/angular": "22.0.5",
+        "@schematics/angular": "22.0.6",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.52.0",
         "ini": "6.0.0",
@@ -3384,14 +3384,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.5.tgz",
-      "integrity": "sha512-e+1Ob5Kxt9QH2Gige0Bl56CXclG819RMl5Fso3kwO58+9AQnR2QxvjbetB7LDRl+YEG3TXCE4s3vdrV4gqRRAQ==",
+      "version": "22.0.6",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.6.tgz",
+      "integrity": "sha512-pZP52HlQaILmFKK4/iA2OyQ7mMP2V/K6z3gxbykWgXk/MNJ605PWaptHZOuvAAp+0qsFWJbj0MLmDdR3yMhdMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "22.0.5",
-        "@angular-devkit/schematics": "22.0.5",
+        "@angular-devkit/core": "22.0.6",
+        "@angular-devkit/schematics": "22.0.6",
         "jsonc-parser": "3.3.1",
         "typescript": "6.0.3"
       },
@@ -8288,9 +8288,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/client/package.json
+++ b/client/package.json
@@ -28,8 +28,8 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@angular/build": "^22.0.5",
-    "@angular/cli": "^22.0.5",
+    "@angular/build": "^22.0.6",
+    "@angular/cli": "^22.0.6",
     "@angular/compiler-cli": "^22.0.6",
     "@tailwindcss/postcss": "^4.3.2",
     "@types/jasmine": "~5.1.0",
@@ -39,7 +39,7 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.2.0",
-    "prettier": "^3.9.3",
+    "prettier": "^3.9.5",
     "tailwindcss": "^4.3.2",
     "typescript": "~6.0.3"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ python-dateutil==2.9.0.post0; python_version >= '2.7' and python_version not in 
 requests==2.34.2; python_version >= '3.9'
 six==1.17.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 typing-extensions==4.16.0; python_version >= '3.9'
-tzdata==2026.2; python_version >= '2'
+tzdata==2026.3; python_version >= '2'
 urllib3==2.7.0; python_version >= '3.9'
 yarl==1.24.2; python_version >= '3.9'


### PR DESCRIPTION
## Summary

Consolidates the 5 open Dependabot PRs (#119, #118, #117, #116, #112) into a single batch on this branch, following the `jeff-skill-dependabot-issue-resolution` process. 4 of 5 updates are applied; `typescript` (#112) is excluded due to a confirmed peer-dependency conflict.

## Checklist walkthrough

**Setup**

- Listed all open Dependabot PRs via `list_pull_requests` (repo-scoped, filtered client-side to `dependabot[bot]`, state=open): #119 (`tzdata`, pip/root), #118 (`@angular/build`, npm/client), #117 (`@angular/cli`, npm/client), #116 (`prettier`, npm/client), #112 (`typescript`, npm/client). All target `main`. Checked `list_issues` (open) -- zero open issues in the repo, so none of the 5 PRs have a linked issue.
- Per explicit override for this run, developed on `claude/exciting-gauss-yc275f` (created off `origin/main`, which was already even with `main` -- no prior work existed on the branch) instead of the skill's default `chore/dependabot-batch-<date>` naming.

**Angular**

- `client/package.json` already had `@angular/core`, `@angular/common`, `@angular/compiler`, `@angular/forms`, `@angular/platform-browser`, `@angular/router`, and `@angular/compiler-cli` pinned to `^22.0.6` (applied in the prior batch, PR #115) -- i.e. Angular itself is already at/past the version this batch's tooling PRs target. Per the skill's "already at or past target" rule, `ng update @angular/core @angular/cli` was not required; the two Angular-tooling devDependency bumps in this batch were applied directly in `package.json`.
- Applied the Angular-constrained bumps: `@angular/build` `22.0.5` -> `22.0.6` (#118) and `@angular/cli` `22.0.5` -> `22.0.6` (#117).
- Ran `npm ls @angular/build @angular/cli` after install -- both resolved cleanly to `22.0.6`, no split versions.
- Confirmed `ng build --configuration=production` and the full Karma/Jasmine test suite (`ChromeHeadlessNoSandbox` via Puppeteer-installed Chrome) passed with just these two bumps applied, before touching anything else.
- Applied the remaining standalone devDependency bump: `prettier` `3.9.4` -> `3.9.5` (#116). Ran `npm ls prettier` -- resolved cleanly to `3.9.5`, no split versions.
- Attempted `typescript` `6.0.3` -> `7.0.2` (#112): `npm install typescript@7.0.2` produced `ERESOLVE overriding peer dependency` warnings -- `@angular/build@22.0.6` and `@angular/compiler-cli@22.0.6` both declare `peerDependency typescript ">=6.0 <6.1"`, which `7.0.2` violates. `npm ls typescript` afterward showed a genuine split-version tree: `typescript@7.0.2` at the top level (marked `invalid`) while `typescript@6.0.3` remained privately nested under `@angular/cli > @schematics/angular`, and the command exited non-zero with `ELSPROBLEMS`. This is a mechanical, confirmed incompatibility -- **excluded from this batch**, matching the same exclusion already recorded on PR #112 in the prior batch (commit `8ec39cc`).
- Reverted the typescript attempt (`package.json`/`package-lock.json` restored, `npm ci` re-run) and re-verified `ng build --configuration=production` + full test suite pass with the final applied set (`@angular/build`, `@angular/cli`, `prettier`).

**Tailwind CSS**

- N/A for this batch -- no open Dependabot PR touches `tailwindcss` or `@tailwindcss/postcss`, and this batch does not cross any Tailwind version boundary. Left untouched.

**Other ecosystems -- pip (root)**

- Applied `tzdata` `2026.2` -> `2026.3` (#119) in `requirements.txt`.
- No pytest/test suite exists in this repo (`test/` contains only `.gitkeep`; `DEVELOPMENT.md` documents no automated Python test command). Verified instead by: creating a fresh venv, `pip install -r requirements.txt` (installs cleanly, `tzdata==2026.3` confirmed via `pip show`), importing every module under `src/` plus `icalendar`/`aiohttp`/`requests`/`dateutil`/`tzdata`/`zoneinfo` (all succeed, `zoneinfo.ZoneInfo('America/New_York')` resolves correctly against the new tzdata data), and running `flake8 src/` (clean, no findings) per the repo's `.flake8` config.
- No ordering dependency vs. the Angular track -- independent ecosystem, applied in parallel.

**Verify**

- `cd client && make lint` -- pass (`prettier --check .` clean).
- `cd client && make test` -- pass (1/1 suite green).
- `cd client && make build` -- pass (production build succeeds, CSP hash already up to date).
- Python: fresh-venv install + import sanity + `flake8` all pass (see above; no formal test suite to run).

**On failure or incompatibility**

- Only one exclusion was needed: `typescript` (#112), root-caused to the exact peer-dependency range violation shown above, confirmed both via `ERESOLVE` warnings and a genuine split-version tree (`npm ls typescript` exit code 1 / `ELSPROBLEMS`). Comment posted on PR #112 with the exact error and range. No linked issue exists to comment on (repo has zero open issues).
- No other dependency in this batch required bisection -- the remaining 4 updates (`@angular/build`, `@angular/cli`, `prettier`, `tzdata`) built/tested/linted cleanly both individually and together.

**Report / finalize**

- Formatting: `make prettier` equivalent (`cd client && npm run prettier:check`) run and passing on all changed files; `requirements.txt` is not a Prettier-supported file type (root `.prettierignore` scope is JS/TS/MD/YAML-oriented), so no formatting step applies to it.
- Full test suite re-run on the branch with everything applied together (see Verify section) -- green.
- On merge: PRs #118, #117, #116, #119 will be closed with a comment linking this PR. PR #112 will be left open (already commented, consistent with the prior batch's precedent).

## Dependency summary

| Dependency | Old -> New | Status |
| --- | --- | --- |
| `@angular/build` (#118) | 22.0.5 -> 22.0.6 | Applied |
| `@angular/cli` (#117) | 22.0.5 -> 22.0.6 | Applied |
| `prettier` (#116) | 3.9.4 -> 3.9.5 | Applied |
| `tzdata` (#119) | 2026.2 -> 2026.3 | Applied |
| `typescript` (#112) | 6.0.3 -> 7.0.2 | **Skipped** -- `@angular/build@22.0.6` and `@angular/compiler-cli@22.0.6` both require `typescript ">=6.0 <6.1"`; 7.0.2 is outside that range. Confirmed via `npm install typescript@7.0.2` (ERESOLVE peer conflicts) and `npm ls typescript` (split-version tree, exit 1). Left open for independent follow-up. |

## Test plan

- [x] `make lint` in `client/`
- [x] `make test` in `client/`
- [x] `make build` in `client/`
- [x] `npm ls` shows no split versions for `@angular/build`, `@angular/cli`, `prettier`
- [x] Fresh venv `pip install -r requirements.txt` + import sanity + `flake8 src/` pass with `tzdata==2026.3`

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKt6HVjyUeSdsNKaqZiWJA)_